### PR TITLE
Stage B2-4｜ 在 `/verifyPurchase` 先做「靜態檢查」

### DIFF
--- a/docs/step02-3/spec.md
+++ b/docs/step02-3/spec.md
@@ -39,7 +39,7 @@
 
 - 驗證時機：在 `verifyPurchase` 進入 Mock/Play 流程前先檢查下列條件。
 - 檢查項目：
-  - packageName：必須存在於 `ALLOWED_PACKAGES`；否則回 400。
+  - packageName：必須等於 `ALLOWED_PACKAGE`；否則回 400。
   - productId：必須存在於 `SKU_MAP`（白名單）；否則回 400。
 - 回應行為：
   - packageName 不在白名單 → `400 { ok:false, reason:"invalid packageName" }`
@@ -65,5 +65,5 @@
 ### 維護說明
 
 - 新增/調整商品時，僅需更新 `functions/src/skuConfig.ts`：
-  - 需要允許新 App 套件時，加到 `ALLOWED_PACKAGES`。
+  - 需要允許新 App 套件時，修改 `ALLOWED_PACKAGE`。
   - 新增商品時，加到 `SKU_MAP` 並標注 `consumable` 或 `nonConsumable`。

--- a/docs/step02-4/spec.md
+++ b/docs/step02-4/spec.md
@@ -1,0 +1,56 @@
+## Stage B2-4｜ 在 `/verifyPurchase` 先做「靜態檢查」
+
+* 在呼叫 Google Play API 之前，先檢查：
+
+  * `packageName === ALLOWED_PACKAGE`
+  * `productId ∈ SKU_MAP`（若不在白名單 → 直接回 `{ok:false, reason:'sku_not_allowed'}`）
+* Google Play API 驗證通過後再回傳 `{ ok: true }`。
+
+#### 給 windsurf 的規格（修改 `verifyPurchase` 流程）
+
+```
+在 functions/src/index.ts 的 verifyPurchase 中：
+1) 解析 req.body（packageName, productId, purchaseToken）
+2) 調用 helper：validateBasic(packageName, productId)
+   - 若 packageName 與 ALLOWED_PACKAGE 不同：回 200, {ok:false, reason:'package_not_allowed'}
+   - 若 productId 不在 SKU_MAP：回 200, {ok:false, reason:'sku_not_allowed'}
+3) 若 USE_PLAY_API=false：走 mock，直接回 200, {ok:true, purchaseState:0, ...}
+4) 若 USE_PLAY_API=true：呼叫 playVerify()，並把結果包回標準型別
+```
+
+---
+## 實作重點（本倉庫對應）
+
+- 檔案：`functions/src/index.ts`
+  - 新增 `validateBasic(packageName, productId)` helper。
+  - 若靜態檢查未通過，統一回 `200` 並帶 `{ ok:false, reason:'package_not_allowed' | 'sku_not_allowed' }`。
+  - 皆通過時才進入 Mock 或（未來）Play API 驗證。
+- 白名單來源：`functions/src/skuConfig.ts` 中 `ALLOWED_PACKAGES` 與 `SKU_MAP`。
+
+## 測試方式（本地）
+
+- 安裝與建置：
+  - `npm i`（根目錄會為 functions workspace 安裝）
+  - `npm test`（會 `tsc` 後以 Node 內建測試跑 `functions/lib/test/**/*.test.js`）
+
+- 單元測試案例（Node `node:test`）：
+  - 合法請求（Mock 模式）：
+    - `packageName: com.example.idleHippo`
+    - `productId: card_click_perm`（或 `SKU_MAP` 內任一鍵）
+    - 期望：`200` 與 `{ ok:true, purchaseState:0, ... }`
+  - 靜態檢查失敗（仍回 200）：
+    - package 不允許 → `200` 與 `{ ok:false, reason:'package_not_allowed' }`
+    - SKU 不允許 → `200` 與 `{ ok:false, reason:'sku_not_allowed' }`
+  - 其他檢查：
+    - 缺少欄位 → `400`（`packageName/productId/purchaseToken` 其一缺失）
+    - CORS 預檢（OPTIONS）→ `204` 並含對應 CORS 標頭
+    - 設定了 `API_KEY` 但未帶/錯誤 → `401`
+
+- cURL（Emulator）範例：
+  - 成功：
+    - `curl -X POST http://localhost:5001/<project>/us-central1/verifyPurchase \
+      -H 'Content-Type: application/json' \
+      -d '{"packageName":"com.example.idleHippo","productId":"card_click_perm","purchaseToken":"token"}'`
+  - 失敗（靜態檢查）：
+    - package 不允許：將 `packageName` 改為 `com.other.app` → `{ok:false, reason:'package_not_allowed'}`
+    - SKU 不允許：將 `productId` 改為 `unknown_sku` → `{ok:false, reason:'sku_not_allowed'}`

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -65,13 +65,11 @@ export const verifyPurchase = onRequest(
     }
 
     try {
-      // B2-3: enforce allowed package and SKU whitelist
-      if (!ALLOWED_PACKAGES.includes(packageName!)) {
-        res.status(400).json({ ok: false, reason: "invalid packageName" });
-        return;
-      }
-      if (!Object.prototype.hasOwnProperty.call(SKU_MAP, productId!)) {
-        res.status(400).json({ ok: false, reason: "invalid productId" });
+      // B2-4: static validation before Play API
+      const basic = validateBasic(packageName!, productId!);
+      if (!basic.ok) {
+        // Per spec: static validation failures return 200 with ok:false
+        res.status(200).json(basic);
         return;
       }
 
@@ -97,3 +95,13 @@ export const verifyPurchase = onRequest(
     }
   })
 );
+
+function validateBasic(packageName: string, productId: string): { ok: true } | { ok: false; reason: string } {
+  if (!ALLOWED_PACKAGES.includes(packageName)) {
+    return { ok: false, reason: "package_not_allowed" };
+  }
+  if (!Object.prototype.hasOwnProperty.call(SKU_MAP, productId)) {
+    return { ok: false, reason: "sku_not_allowed" };
+  }
+  return { ok: true };
+}

--- a/functions/test/verifyPurchase.test.ts
+++ b/functions/test/verifyPurchase.test.ts
@@ -123,7 +123,7 @@ describe('verifyPurchase (mock)', () => {
     assert.equal(res.body.ok, false);
   });
 
-  it('rejects disallowed packageName with 400', async () => {
+  it('rejects disallowed packageName with 200 + ok:false', async () => {
     const req = makeReq({
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -136,12 +136,12 @@ describe('verifyPurchase (mock)', () => {
     const res = new MockRes();
     await functions.verifyPurchase(req, res);
     await res.finished;
-    assert.equal(res.statusCode, 400);
+    assert.equal(res.statusCode, 200);
     assert.equal(res.body.ok, false);
-    assert.equal(res.body.reason, 'invalid packageName');
+    assert.equal(res.body.reason, 'package_not_allowed');
   });
 
-  it('rejects productId not in SKU_MAP with 400', async () => {
+  it('rejects productId not in SKU_MAP with 200 + ok:false', async () => {
     const req = makeReq({
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -154,9 +154,9 @@ describe('verifyPurchase (mock)', () => {
     const res = new MockRes();
     await functions.verifyPurchase(req, res);
     await res.finished;
-    assert.equal(res.statusCode, 400);
+    assert.equal(res.statusCode, 200);
     assert.equal(res.body.ok, false);
-    assert.equal(res.body.reason, 'invalid productId');
+    assert.equal(res.body.reason, 'sku_not_allowed');
   });
 });
  


### PR DESCRIPTION
## Stage B2-4｜ 在 `/verifyPurchase` 先做「靜態檢查」

* 在呼叫 Google Play API 之前，先檢查：

  * `packageName === ALLOWED_PACKAGE`
  * `productId ∈ SKU_MAP`（若不在白名單 → 直接回 `{ok:false, reason:'sku_not_allowed'}`）
* Google Play API 驗證通過後再回傳 `{ ok: true }`。

#### 給 windsurf 的規格（修改 `verifyPurchase` 流程）

```
在 functions/src/index.ts 的 verifyPurchase 中：
1) 解析 req.body（packageName, productId, purchaseToken）
2) 調用 helper：validateBasic(packageName, productId)
   - 若 packageName 與 ALLOWED_PACKAGE 不同：回 200, {ok:false, reason:'package_not_allowed'}
   - 若 productId 不在 SKU_MAP：回 200, {ok:false, reason:'sku_not_allowed'}
3) 若 USE_PLAY_API=false：走 mock，直接回 200, {ok:true, purchaseState:0, ...}
4) 若 USE_PLAY_API=true：呼叫 playVerify()，並把結果包回標準型別
```

---
## 實作重點（本倉庫對應）

- 檔案：`functions/src/index.ts`
  - 新增 `validateBasic(packageName, productId)` helper。
  - 若靜態檢查未通過，統一回 `200` 並帶 `{ ok:false, reason:'package_not_allowed' | 'sku_not_allowed' }`。
  - 皆通過時才進入 Mock 或（未來）Play API 驗證。
- 白名單來源：`functions/src/skuConfig.ts` 中 `ALLOWED_PACKAGES` 與 `SKU_MAP`。

## 測試方式（本地）

- 安裝與建置：
  - `npm i`（根目錄會為 functions workspace 安裝）
  - `npm test`（會 `tsc` 後以 Node 內建測試跑 `functions/lib/test/**/*.test.js`）

- 單元測試案例（Node `node:test`）：
  - 合法請求（Mock 模式）：
    - `packageName: com.example.idleHippo`
    - `productId: card_click_perm`（或 `SKU_MAP` 內任一鍵）
    - 期望：`200` 與 `{ ok:true, purchaseState:0, ... }`
  - 靜態檢查失敗（仍回 200）：
    - package 不允許 → `200` 與 `{ ok:false, reason:'package_not_allowed' }`
    - SKU 不允許 → `200` 與 `{ ok:false, reason:'sku_not_allowed' }`
  - 其他檢查：
    - 缺少欄位 → `400`（`packageName/productId/purchaseToken` 其一缺失）
    - CORS 預檢（OPTIONS）→ `204` 並含對應 CORS 標頭
    - 設定了 `API_KEY` 但未帶/錯誤 → `401`

- cURL（Emulator）範例：
  - 成功：
    - `curl -X POST http://localhost:5001/<project>/us-central1/verifyPurchase \
      -H 'Content-Type: application/json' \
      -d '{"packageName":"com.example.idleHippo","productId":"card_click_perm","purchaseToken":"token"}'`
  - 失敗（靜態檢查）：
    - package 不允許：將 `packageName` 改為 `com.other.app` → `{ok:false, reason:'package_not_allowed'}`
    - SKU 不允許：將 `productId` 改為 `unknown_sku` → `{ok:false, reason:'sku_not_allowed'}`
